### PR TITLE
[tracker] Fix uninitialized variable in libav extractor.

### DIFF
--- a/tracker/src/tracker-extract/tracker-extract-libav.c
+++ b/tracker/src/tracker-extract/tracker-extract-libav.c
@@ -125,7 +125,7 @@ tracker_extract_get_metadata (TrackerExtractInfo *info)
 	AVStream *video_stream = NULL;
 	int streamIndex;
 	AVDictionaryEntry *tag = NULL;
-	const char *title;
+	const char *title = NULL;
 
 	av_register_all();
 

--- a/tracker/src/tracker-extract/tracker-extract-vorbis.c
+++ b/tracker/src/tracker-extract/tracker-extract-vorbis.c
@@ -502,7 +502,7 @@ tracker_extract_get_metadata (TrackerExtractInfo *info)
 
 	uri = g_file_get_uri (file);
 	tracker_media_art_process (NULL,
-				NULL,
+				0,
 				NULL,
 				TRACKER_MEDIA_ART_ALBUM,
 				vd.album_artist ? vd.album_artist : vd.artist,


### PR DESCRIPTION
And warning about passing NULL to an argument that takes an int in
vorbis extractor.
