### PR TITLE
[tracker] Ensure video size is extracted by libav extractor.

### DIFF
--- a/tracker/src/tracker-extract/Makefile.am
+++ b/tracker/src/tracker-extract/Makefile.am
@@ -489,8 +489,9 @@ libextract_libav_la_LIBADD = \
 	$(top_builddir)/src/libtracker-common/libtracker-common.la \
 	$(BUILD_LIBS) \
 	$(TRACKER_EXTRACT_MODULES_LIBS) \
-        $(AVFORMAT_LIBS) \
-        $(AVUTIL_LIBS)
+	$(AVFORMAT_LIBS) \
+	$(AVUTIL_LIBS) \
+	$(AVCODEC_LIBS)
 
 
 #


### PR DESCRIPTION
It may be necessary to parse the MPEG bitstream to get width and height
from some videos so if the resolution isn't immediately available decode
enough data to determine it.
