### PR TITLE
Add an empty BMP extractor to get the rdf:type for the file type right

### DIFF
--- a/tracker/src/tracker-extract/10-bmp.rule
+++ b/tracker/src/tracker-extract/10-bmp.rule
@@ -1,0 +1,4 @@
+[ExtractorRule]
+ModulePath=libextract-bmp.so
+MimeTypes=image/bmp
+

--- a/tracker/src/tracker-extract/Makefile.am
+++ b/tracker/src/tracker-extract/Makefile.am
@@ -36,6 +36,7 @@ rules_files = \
 	10-vorbis.rule \
 	10-xmp.rule \
 	10-xps.rule \
+	10-bmp.rule \
 	11-iso.rule \
 	11-msoffice-xml.rule \
 	15-gstreamer-guess.rule \
@@ -178,6 +179,9 @@ if HAVE_LIBAV
 extractmodules_LTLIBRARIES += libextract-libav.la
 rules_DATA += 90-libav-generic.rule
 endif
+
+extractmodules_LTLIBRARIES += libextract-bmp.la
+rules_DATA += 10-bmp.rule
 
 # ABW
 libextract_abw_la_SOURCES = tracker-extract-abw.c
@@ -513,6 +517,17 @@ libextract_libav_la_LIBADD = \
 	$(AVUTIL_LIBS) \
 	$(AVCODEC_LIBS)
 
+
+# BMP
+libextract_bmp_la_SOURCES = tracker-extract-bmp.c
+libextract_bmp_la_CFLAGS = \
+	$(TRACKER_EXTRACT_MODULES_CFLAGS)
+libextract_bmp_la_LDFLAGS = $(module_flags)
+libextract_bmp_la_LIBADD = \
+	$(top_builddir)/src/libtracker-extract/libtracker-extract-@TRACKER_API_VERSION@.la \
+	$(top_builddir)/src/libtracker-common/libtracker-common.la \
+	$(BUILD_LIBS) \
+	$(TRACKER_EXTRACT_MODULES_LIBS)
 
 #
 # Binaries

--- a/tracker/src/tracker-extract/tracker-extract-bmp.c
+++ b/tracker/src/tracker-extract/tracker-extract-bmp.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2013-2014 Jolla Ltd. <andrew.den.exter@jollamobile.com>
+ * Author: Philip Van Hoof <philip@codeminded.be>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#include "config.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <libtracker-common/tracker-common.h>
+#include <libtracker-extract/tracker-extract.h>
+
+
+G_MODULE_EXPORT gboolean
+tracker_extract_get_metadata (TrackerExtractInfo *info)
+{
+	TrackerSparqlBuilder *preupdate, *metadata;
+	goffset size;
+	const gchar *graph;
+	gchar *filename, *uri;
+	GFile *file;
+
+	preupdate = tracker_extract_info_get_preupdate_builder (info);
+	metadata = tracker_extract_info_get_metadata_builder (info);
+	graph = tracker_extract_info_get_graph (info);
+
+	file = tracker_extract_info_get_file (info);
+	filename = g_file_get_path (file);
+	size = tracker_file_get_size (filename);
+
+	if (size < 14) {
+		/* Smaller than BMP header, can't be a real BMP file */
+		g_free (filename);
+		return FALSE;
+	}
+
+	tracker_sparql_builder_predicate (metadata, "a");
+	tracker_sparql_builder_object (metadata, "nfo:Image");
+	tracker_sparql_builder_object (metadata, "nmm:Photo");
+
+	/* TODO: Add actual metadata extraction for BMP files */
+
+	return TRUE;
+}

--- a/tracker/src/tracker-extract/tracker-extract.c
+++ b/tracker/src/tracker-extract/tracker-extract.c
@@ -427,7 +427,7 @@ extract_task_new (TrackerExtract *extract,
 		}
 
 		mimetype_used = g_strdup (g_file_info_get_content_type (info));
-		g_debug ("Guessing mime type as '%s'", mimetype);
+		g_debug ("Guessing mime type as '%s'", mimetype_used);
 		g_object_unref (info);
 	} else {
 		mimetype_used = g_strdup (mimetype);


### PR DESCRIPTION
This adds an empty BMP extractor so that the rdf:type for BMP files will be right. Extracting actual metadata is todo.
