### PR TITLE
[libtracker-data] Limit error message length

### DIFF
--- a/tracker/src/libtracker-common/tracker-utils.c
+++ b/tracker/src/libtracker-common/tracker-utils.c
@@ -210,3 +210,29 @@ tracker_strhex (const guint8 *data,
 	return new_str;
 }
 
+/**
+ * tracker_utf8_truncate:
+ * @str: Nul-terminated input string
+ * @max_size: Maximum length of the output string
+ *
+ * Returns up to @max_size characters long substring of @str, followed
+ * with "[…]" when actually truncated.
+ *
+ * Returns: A newly allocated string which should be disposed with g_free()
+ */
+gchar *
+tracker_utf8_truncate (const gchar  *str,
+                       gsize         max_size)
+{
+	gchar *retv = NULL;
+
+	if (g_utf8_strlen (str, -1) > max_size) {
+		gchar *substring = g_utf8_substring (str, 0, max_size - 3);
+		retv = g_strdup_printf ("%s[…]", substring);
+		g_free (substring);
+	} else {
+		retv = g_strdup (str);
+	}
+
+	return retv;
+}

--- a/tracker/src/libtracker-common/tracker-utils.h
+++ b/tracker/src/libtracker-common/tracker-utils.h
@@ -43,6 +43,8 @@ gchar *  tracker_seconds_to_string          (gdouble       seconds,
 gchar *  tracker_strhex                     (const guint8 *data,
                                              gsize         size,
                                              gchar         delimiter);
+gchar *  tracker_utf8_truncate              (const gchar  *str,
+                                             gsize         max_size);
 
 G_END_DECLS
 

--- a/tracker/src/libtracker-data/tracker-data-update.c
+++ b/tracker/src/libtracker-data/tracker-data-update.c
@@ -1699,8 +1699,8 @@ cache_insert_metadata_decomposed (TrackerProperty  *property,
 		GValue old_value = { 0 };
 		GValue new_value = { 0 };
 		GValue *v;
-		const gchar *old_value_str = NULL;
-		const gchar *new_value_str = NULL;
+		gchar *old_value_str = NULL;
+		gchar *new_value_str = NULL;
 
 		g_value_init (&old_value, G_TYPE_STRING);
 		g_value_init (&new_value, G_TYPE_STRING);
@@ -1709,12 +1709,12 @@ cache_insert_metadata_decomposed (TrackerProperty  *property,
 		 * whatever transformation needed */
 		v = &g_array_index (old_values, GValue, 0);
 		if (g_value_transform (v, &old_value)) {
-			old_value_str = g_value_get_string (&old_value);
+			old_value_str = tracker_utf8_truncate (g_value_get_string (&old_value), 255);
 		}
 
 		v = &g_array_index (old_values, GValue, 1);
 		if (g_value_transform (v, &new_value)) {
-			new_value_str = g_value_get_string (&new_value);
+			new_value_str = tracker_utf8_truncate (g_value_get_string (&new_value), 255);
 		}
 
 		g_set_error (error, TRACKER_SPARQL_ERROR, TRACKER_SPARQL_ERROR_CONSTRAINT,
@@ -1725,6 +1725,8 @@ cache_insert_metadata_decomposed (TrackerProperty  *property,
 		             old_value_str ? old_value_str : "<untransformable>",
 		             new_value_str ? new_value_str : "<untransformable>");
 
+		g_free (old_value_str);
+		g_free (new_value_str);
 		g_value_unset (&old_value);
 		g_value_unset (&new_value);
 		g_value_unset (&gvalue);


### PR DESCRIPTION
When a very long error message is eventually sent over D-Bus and the
original method call involves file descriptor passing, it hits Gnome bug
732615 and the sending process gets aborted.

https://bugzilla.gnome.org/show_bug.cgi?id=732839