### PR TITLE
[rpm] Make tracker package own its directories. Contributes JB#22780

### DIFF
--- a/rpm/tracker-libav.spec
+++ b/rpm/tracker-libav.spec
@@ -220,6 +220,16 @@ cd /usr/share/tracker-tests/
 %{_datadir}/tracker/ontologies/*
 %{_datadir}/vala/vapi/*
 %{_datadir}/tracker/extract-rules/*
+%dir %{_datadir}/tracker
+%dir %{_datadir}/tracker/languages
+%dir %{_datadir}/tracker/miners
+%dir %{_datadir}/tracker/ontologies
+%dir %{_datadir}/tracker/extract-rules
+%dir %{_datadir}/vala
+%dir %{_datadir}/vala/vapi
+%dir %{_libdir}/tracker-*
+%dir %{_libdir}/tracker-*/extract-modules
+%dir %{_libdir}/tracker-*/writeback-modules
 %{_datadir}/glib-2.0/schemas/*.xml
 %{_libdir}/libtracker-miner-*.so*
 %{_libdir}/libtracker-sparql-*.so*

--- a/rpm/tracker.spec
+++ b/rpm/tracker.spec
@@ -227,6 +227,16 @@ cd /usr/share/tracker-tests/
 %{_libdir}/tracker-*/*.so*
 %{_libdir}/tracker-*/extract-modules/*.so*
 %{_libdir}/tracker-*/writeback-modules/*.so*
+%dir %{_datadir}/tracker
+%dir %{_datadir}/tracker/languages
+%dir %{_datadir}/tracker/miners
+%dir %{_datadir}/tracker/ontologies
+%dir %{_datadir}/tracker/extract-rules
+%dir %{_datadir}/vala
+%dir %{_datadir}/vala/vapi
+%dir %{_libdir}/tracker-*
+%dir %{_libdir}/tracker-*/extract-modules
+%dir %{_libdir}/tracker-*/writeback-modules
 %{_libexecdir}/tracker-extract
 %{_libexecdir}/tracker-miner-fs
 %{_libexecdir}/tracker-store


### PR DESCRIPTION
Make tracker package own the directories it creates on install.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
