### PR TITLE
[extract] tracker-extract: mp3 passes album instead of song title to libmediaart

### DIFF
--- a/tracker/src/tracker-extract/tracker-extract-mp3.c
+++ b/tracker/src/tracker-extract/tracker-extract-mp3.c
@@ -2647,7 +2647,7 @@ tracker_extract_get_metadata (TrackerExtractInfo *info)
 	mp3_parse (buffer, buffer_size, audio_offset, uri, metadata, &md);
 
 #ifdef HAVE_LIBMEDIAART
-	if (md.performer || md.title) {
+	if (md.performer || md.album) {
 		MediaArtProcess *media_art_process;
 		GError *error = NULL;
 		gboolean success = TRUE;
@@ -2663,7 +2663,7 @@ tracker_extract_get_metadata (TrackerExtractInfo *info)
 			                                    md.media_art_size,
 			                                    md.media_art_mime,
 			                                    md.performer,
-			                                    md.title,
+			                                    md.album,
 			                                    &error);
 		} else {
 			success = media_art_process_file (media_art_process,
@@ -2671,7 +2671,7 @@ tracker_extract_get_metadata (TrackerExtractInfo *info)
 			                                  MEDIA_ART_PROCESS_FLAGS_NONE,
 			                                  file,
 			                                  md.performer,
-			                                  md.title,
+			                                  md.album,
 			                                  &error);
 		}
 


### PR DESCRIPTION
As explained at
https://wiki.gnome.org/MediaArtStorageSpec and
implemented in other extractors, the strings to
pass in order to generate the album art are the
artist and the album title.

https://bugzilla.gnome.org/show_bug.cgi?id=745219