### PR TITLE
[miner] Fix mining of files whose data was inserted by app

### DIFF
--- a/tracker/src/libtracker-miner/tracker-miner-fs.c
+++ b/tracker/src/libtracker-miner/tracker-miner-fs.c
@@ -1511,7 +1511,7 @@ item_add_or_update (TrackerMinerFS *fs,
 	 * created, its meta data might already be in the store
 	 * (possibly inserted by other application) - in such a case
 	 * we have to UPDATE, not INSERT. */
-	urn = lookup_file_urn (fs, file, FALSE);
+	urn = lookup_file_urn (fs, file, TRUE);
 
 	if (!tracker_indexing_tree_file_is_root (fs->priv->indexing_tree, file)) {
 		parent = g_file_get_parent (file);


### PR DESCRIPTION
If an app inserts file data into the store before a file is created, the tracker-miner will misbehave and construct bad sparql statements instead of extracting more data from the new file.

User-visible effect: new pictures don't show up in Gallery, etc.

This patch to fix it was taken from
  https://bugzilla.gnome.org/show_bug.cgi?id=678986

Upstream is still debating its inclusion because of performance concerns, but at least it fixes the problem for us.